### PR TITLE
Upgrade omniauth-clever to support Clever 3.0

### DIFF
--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -42,10 +42,12 @@ module OmniAuth
         end
       end
 
-      uid{ raw_info['data']['id'] }
+      uid { raw_info['data']['id'] }
 
       info do
-        { :user_type => raw_info['type'] }.merge! raw_info['data']
+        {
+          :user_type => raw_info['type']
+        }.merge! raw_info['data']
       end
 
       extra do
@@ -55,7 +57,13 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/me').parsed
+        # As of January 1, 2023, Clever no longer returns user info with the /me call. For
+        # compatibility with other API providers, we request that info and merge it in.
+        @raw_info ||= begin
+                        account_data = access_token.get('/v3.0/me').parsed
+                        profile_data = access_token.get("/v3.0/users/#{uid}").parsed
+                        account_data.merge("data" => profile_data["data"].merge(account_data["data"]))
+                      end
       end
 
       # Fix unknown redirect uri bug by NOT appending the query string to the callback url.

--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -61,7 +61,7 @@ module OmniAuth
         # compatibility with other API providers, we request that info and merge it in.
         @raw_info ||= begin
                         account_data = access_token.get('/v3.0/me').parsed
-                        profile_data = access_token.get("/v3.0/users/#{uid}").parsed
+                        profile_data = access_token.get("/v3.0/users/#{account_data["data"]["id"]}").parsed
                         account_data.merge("data" => profile_data["data"].merge(account_data["data"]))
                       end
       end


### PR DESCRIPTION
At the end of 2022, Clever shut off their old APIs. The new V3 API returns different data than V1 -- instead of getting back user info from `/me`, we only get back the user's token and ID and have to make a request to the user API.

This PR brings the `omniauth-clever` gem up to date with the 3.0 API. To maintain compatibility with existing code and parity with other OAuth providers, we make the second API call inline so that we can return the complete user data as expected.